### PR TITLE
Phone numbers dependencies chain

### DIFF
--- a/src/pstnAudio.ts
+++ b/src/pstnAudio.ts
@@ -51,6 +51,9 @@ export class PSTNAudio extends Construct {
       },
     );
 
+    salesPhoneNumber.node.addDependency(inboundPhoneNumber);
+    supportPhoneNumber.node.addDependency(salesPhoneNumber);
+
     const smaHandlerRole = new iam.Role(this, 'smaHandlerRole', {
       assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
       inlinePolicies: {


### PR DESCRIPTION
While trying to deploy the sample, there was an error in creating the inboundPhoneNumber.
![image](https://user-images.githubusercontent.com/75750855/226947775-dd7a91ad-043e-42e8-9ea3-1c36f3946ccb.png)

It seemed to happen because the phone number creation first looks for an available number and the assigns it. So when trying to create two simultaneously, they take the same number, and one failed. 

This PR just add a chain of dependencies among the phone number so the are created one at a time. 